### PR TITLE
add show/hide for inventory delete buttons

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -123,9 +123,13 @@ void CheckEditorLabels(CGameCtnEditorFree@ editor, bool force = false) {
         if (!force && lastMobilsLength == scene.Mobils.Length) return;
         for (uint i = 0; i < scene.Mobils.Length; i++) {
             auto mobil = scene.Mobils[i];
-            if (mobil.Id.GetName() != "EntryInfos") continue;
+            auto mobileIdName = mobil.Id.GetName();
+            if (mobileIdName == "EntryInfos") {
             // if (mobil.Id.Value != 0x40005b9b) continue; // changes each launch it seems
-            mobil.IsVisible = S_ShowBlockLabels;
+                mobil.IsVisible = S_ShowBlockLabels;
+            } else if (mobileIdName == "FrameRemove") {
+                mobil.IsVisible = !S_HideCustomObjectDelete;
+            }
         }
     }
     /*

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -22,6 +22,9 @@ bool S_HideMapInfo = false;
 bool S_ShowBlockLabels = false;
 
 [Setting hidden]
+bool S_HideCustomObjectDelete = false;
+
+[Setting hidden]
 bool S_AlwaysShowEditor = false;
 
 [Setting hidden]
@@ -46,6 +49,7 @@ void S_RenderIntroTab() {
 void S_RenderUIScaleTab() {
     vec4 orig_EditorDrawBounds = vec4(S_EditorDrawBounds);
     bool orig_ShowBlockLabels = S_ShowBlockLabels;
+    bool orig_HideCustomObjectDelete = S_HideCustomObjectDelete;
 
     Heading("Editor UI Options");
     bool origVanilla = S_VanillaUIScaleOnly;
@@ -66,6 +70,9 @@ void S_RenderUIScaleTab() {
 
     S_ShowBlockLabels = UI::Checkbox("Show All Block Labels in Inventory?" + TTIndicator, S_ShowBlockLabels);
     AddSimpleTooltip("This will enable labels for the folders / blocks in the inventory.\nThese aren't usually visible.\nTo disable, you might need to restart the editor/game.");
+
+    S_HideCustomObjectDelete = UI::Checkbox("Hide Custom Block/Item/Macroblock Delete button?" + TTIndicator, S_HideCustomObjectDelete);
+    AddSimpleTooltip("This will hide the \"X\" button in the top-right corner of custom\nblocks, items, or macroblocks.");
 
     S_AutoHideInventory = UI::Checkbox("Auto-hide the Inventory? (Auto TAB)" + TTIndicator, S_AutoHideInventory);
     AddSimpleTooltip("This will auto-hide the inventory (blocks / items / macroblocks / etc) when the mouse\nis not hovering over it, and re-show it when the mouse enters that region again.\nUseful in fullscreen mode. Also helps with phantom misclicks.");
@@ -116,7 +123,7 @@ void S_RenderUIScaleTab() {
         startnew(OnSettingsChanged);
     }
 
-    if (orig_ShowBlockLabels != S_ShowBlockLabels) {
+    if (orig_ShowBlockLabels != S_ShowBlockLabels || orig_HideCustomObjectDelete != S_HideCustomObjectDelete) {
         g_EditorLabelsDone = false;
     }
 }


### PR DESCRIPTION
This adds a new setting to be able to hide the delete button on custom inventory items.
Before:
![image](https://user-images.githubusercontent.com/52106022/236965862-eedece6b-c1b8-4395-bcd0-4546fc9f3dce.png)
After:
![image](https://user-images.githubusercontent.com/52106022/236965889-9e0ee04e-ac5f-41a1-b004-744410586dcb.png)

I've been personally wanting this for a while because I am not often deleting my custom items from inside the game and it also looks a little ugly to have all those x's (imo).